### PR TITLE
feat: add --ci mode and prompt passing for non-interactive shuvcode execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,71 @@ export WORKTREE_ROOT=/path/to/worktrees
 ghwt https://github.com/owner/repo/issues/42
 ```
 
+### Prompt Passing to Shuvcode
+
+By default, ghwt passes WT-TASK.md content to shuvcode as initial prompt.
+
+**Custom Prompt:**
+```bash
+ghwt 42 --issue --agent-prompt "Fix database connection error"
+```
+
+**Prompt Presets:**
+```bash
+ghwt 42 --issue --agent-preset ralph-loop
+ghwt 42 --issue --agent-preset standard-ootl
+ghwt 42 --issue --agent-preset minimal
+```
+
+**CI Mode (Non-Interactive):**
+```bash
+ghwt 42 --issue --ci
+```
+
+**Disable Prompt (Old Behavior):**
+```bash
+ghwt 42 --issue --no-prompt
+```
+
+**Environment Variables:**
+```bash
+export GHWT_AGENT_INIT_PROMPT="Custom default prompt"
+export GHWT_AGENT_INIT_PRESET="ralph-loop"
+export GHWT_CI_MODE=true
+```
+
+### CI/CD Integration
+
+**GitHub Actions:**
+```yaml
+- name: Create worktree and start agent
+  env:
+    GHWT_AGENT_INIT_PRESET: "ralph-loop"
+  run: |
+    ghwt ${{ github.event.pull_request.number }} --pr --ci
+```
+
+**GitLab CI:**
+```yaml
+variables:
+  GHWT_AGENT_INIT_PROMPT: "/ralph-loop Execute WT-TASK.md task"
+
+create_worktree:
+  script:
+    - ghwt $CI_MERGE_REQUEST_IID --pr --ci
+```
+
+**Note:** The `--ci` flag automatically sets `OPENCODE_PERMISSION='{"*":"allow"}'` to skip all permission prompts in CI environments. This enables fully non-interactive execution.
+
+### Priority Order
+
+Prompt resolution follows this priority (highest to lowest):
+1. `--agent-prompt` CLI flag (custom prompt override)
+2. `GHWT_AGENT_INIT_PROMPT` environment variable
+3. `--agent-preset` CLI flag or `GHWT_AGENT_INIT_PRESET` environment variable
+4. WT-TASK.md file content (default)
+5. No prompt (`--no-prompt` flag)
+
 ### Output
 
 The tool generates a `WT-TASK.md` file in the worktree directory with:

--- a/main.py
+++ b/main.py
@@ -48,6 +48,28 @@ from worktree_creator import WorktreeCreator
     default=None,
     help="Root directory for worktrees (default: <git_repo>/.worktrees/)",
 )
+@click.option(
+    "--agent-prompt",
+    type=str,
+    default=None,
+    help="Custom prompt to pass to shuvcode (overrides preset and WT-TASK.md)",
+)
+@click.option(
+    "--agent-preset",
+    type=click.Choice(["ralph-loop", "standard-ootl", "minimal"]),
+    default=None,
+    help="Use predefined prompt preset for shuvcode",
+)
+@click.option(
+    "--no-prompt",
+    is_flag=True,
+    help="Skip prompt passing to shuvcode (current behavior)",
+)
+@click.option(
+    "--ci",
+    is_flag=True,
+    help="CI mode: non-interactive shuvcode execution with WT-TASK.md as prompt",
+)
 def cli(
     input: str,
     item_type: str | None,
@@ -55,6 +77,10 @@ def cli(
     verbose: bool,
     quiet: bool,
     worktree_root: Path | None,
+    agent_prompt: str | None,
+    agent_preset: str | None,
+    no_prompt: bool,
+    ci: bool,
 ) -> None:
     """Create worktree from GitHub issue or PR.
 
@@ -74,11 +100,25 @@ def cli(
         2. Create a worktree using workmux (skip with --dry-run)
         3. Generate WT-TASK.md with comprehensive autonomous agent instructions
         4. Auto-open shuvcode editor on worktree (skip with --dry-run)
+
+    Prompt passing:
+        --agent-prompt "Custom prompt": Override default prompt
+        --agent-preset ralph-loop: Use predefined preset
+        --ci: Non-interactive mode with WT-TASK.md as prompt
+        --no-prompt: Skip prompt (old behavior)
     """
+    # Handle mutually exclusive CI flags
+    if ci and no_prompt:
+        raise click.ClickException("Cannot use --ci and --no-prompt together")
+
     settings = WorktreeSettings(
         worktree_root=worktree_root,
         verbose=verbose,
         quiet=quiet,
+        agent_prompt=agent_prompt,
+        agent_prompt_preset=agent_preset,
+        no_prompt=no_prompt,
+        ci_mode=ci,
     )
 
     configure_logging(verbose=settings.verbose, quiet=settings.quiet)

--- a/tests/unit/test_prompt_passing.py
+++ b/tests/unit/test_prompt_passing.py
@@ -1,0 +1,346 @@
+"""Tests for prompt passing to shuvcode."""
+
+from pathlib import Path
+
+import pytest
+from config import WorktreeSettings, PromptPreset
+from models import IssueData
+from worktree_creator import WorktreeCreator
+from unittest.mock import Mock, patch
+
+
+@pytest.fixture
+def temp_worktree_root(tmp_path: Path) -> Path:
+    """Temporary directory for worktree operations."""
+    worktree_dir = tmp_path / ".worktrees"
+    worktree_dir.mkdir()
+    yield worktree_dir
+
+
+@pytest.fixture
+def sample_issue_data() -> IssueData:
+    """Sample issue data."""
+    from models import CommentData
+
+    return IssueData(
+        title="Fix database connection error",
+        body="Database fails when connecting...",
+        number=42,
+        author="testuser",
+        labels=["bug", "high"],
+        state="open",
+        url="https://github.com/repo/issues/42",
+        comments=[
+            CommentData(
+                author="user2",
+                body="I can reproduce",
+                created_at="2024-01-01T10:00:00Z",
+            ),
+        ],
+    )
+
+
+class TestPromptResolution:
+    """Test prompt resolution logic."""
+
+    def test_resolve_custom_prompt(self, temp_worktree_root: Path) -> None:
+        """Test custom prompt takes priority over all sources."""
+        settings = WorktreeSettings(
+            worktree_root=temp_worktree_root,
+            agent_prompt="Custom agent instruction",
+        )
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        prompt = creator._resolve_shuvcode_prompt(worktree_path)
+
+        assert prompt == "Custom agent instruction"
+
+    def test_resolve_preset_prompt(self, temp_worktree_root: Path) -> None:
+        """Test preset prompt takes priority over WT-TASK.md."""
+        settings = WorktreeSettings(
+            worktree_root=temp_worktree_root,
+            agent_prompt_preset=PromptPreset.RALPH_LOOP,
+        )
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        prompt = creator._resolve_shuvcode_prompt(worktree_path)
+
+        assert "Follow Ralph's autonomous development loop" in prompt
+
+    def test_resolve_wt_task_prompt(
+        self, temp_worktree_root: Path, sample_issue_data: IssueData
+    ) -> None:
+        """Test WT-TASK.md content is used when no custom prompt or preset."""
+        settings = WorktreeSettings(worktree_root=temp_worktree_root)
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        # Create WT-TASK.md
+        task_file = worktree_path / "WT-TASK.md"
+        task_file.write_text("Test WT-TASK content")
+
+        prompt = creator._resolve_shuvcode_prompt(worktree_path)
+
+        assert prompt == "Test WT-TASK content"
+
+    def test_resolve_none_when_no_prompt_available(
+        self, temp_worktree_root: Path
+    ) -> None:
+        """Test None is returned when no prompt source available."""
+        settings = WorktreeSettings(worktree_root=temp_worktree_root, no_prompt=True)
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        # Don't create WT-TASK.md
+        prompt = creator._resolve_shuvcode_prompt(worktree_path)
+
+        assert prompt is None
+
+
+class TestShuvcodeCommands:
+    """Test shuvcode command generation."""
+
+    @patch("subprocess.run")
+    def test_shuvcode_with_wt_task_prompt(
+        self, mock_run: Mock, temp_worktree_root: Path, sample_issue_data: IssueData
+    ) -> None:
+        """Test shuvcode receives WT-TASK.md as prompt."""
+
+        # Track subprocess calls
+        calls = []
+
+        def track_calls(*args, **kwargs):
+            calls.append(list(args[0]) if args else [])
+            mock_result = Mock()
+            mock_result.stdout = ""
+            mock_result.returncode = 0
+            return mock_result
+
+        mock_run.side_effect = track_calls
+
+        settings = WorktreeSettings(worktree_root=temp_worktree_root)
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        # Create WT-TASK.md
+        task_file = worktree_path / "WT-TASK.md"
+        task_file.write_text("Test task content")
+
+        # Open shuvcode
+        creator._open_shuvcode(worktree_path)
+
+        # Find shuvcode call
+        shuvcode_calls = [c for c in calls if "shuvcode" in c]
+        assert len(shuvcode_calls) == 1
+
+        cmd = shuvcode_calls[0]
+        assert "shuvcode" in cmd
+        assert str(worktree_path) in cmd
+        assert "--prompt" in cmd
+        # Verify prompt content passed
+        prompt_index = cmd.index("--prompt") + 1
+        assert cmd[prompt_index] == "Test task content"
+
+    @patch("subprocess.run")
+    def test_ci_mode_uses_run_command(
+        self, mock_run: Mock, temp_worktree_root: Path, sample_issue_data: IssueData
+    ) -> None:
+        """Test CI mode uses 'shuvcode run' command."""
+        # Track subprocess calls
+        calls = []
+
+        def track_calls(*args, **kwargs):
+            calls.append(list(args[0]) if args else [])
+            mock_result = Mock()
+            mock_result.stdout = ""
+            mock_result.returncode = 0
+            return mock_result
+
+        mock_run.side_effect = track_calls
+
+        settings = WorktreeSettings(worktree_root=temp_worktree_root, ci_mode=True)
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        # Create WT-TASK.md
+        task_file = worktree_path / "WT-TASK.md"
+        task_file.write_text("Test task content")
+
+        # Open shuvcode in CI mode
+        creator._open_shuvcode(worktree_path)
+
+        # Find shuvcode call
+        shuvcode_calls = [c for c in calls if "shuvcode" in c]
+        assert len(shuvcode_calls) == 1
+
+        cmd = shuvcode_calls[0]
+        assert "shuvcode" in cmd
+        assert "run" in cmd
+        assert "--prompt" not in cmd  # No --prompt flag in CI mode
+        # Verify prompt content passed directly to 'run' command
+        run_index = cmd.index("run") + 1
+        assert cmd[run_index] == "Test task content"
+
+    @patch("subprocess.run")
+    def test_no_prompt_skips_prompt_flag(
+        self, mock_run: Mock, temp_worktree_root: Path, sample_issue_data: IssueData
+    ) -> None:
+        """Test --no-prompt flag skips prompt passing."""
+        # Track subprocess calls
+        calls = []
+
+        def track_calls(*args, **kwargs):
+            calls.append(
+                {"cmd": list(args[0]) if args else [], "env": kwargs.get("env")}
+            )
+            mock_result = Mock()
+            mock_result.stdout = ""
+            mock_result.returncode = 0
+            return mock_result
+
+        mock_run.side_effect = track_calls
+
+        settings = WorktreeSettings(worktree_root=temp_worktree_root, no_prompt=True)
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        # Create WT-TASK.md
+        task_file = worktree_path / "WT-TASK.md"
+        task_file.write_text("Test task content")
+
+        # Open shuvcode with no-prompt
+        creator._open_shuvcode(worktree_path)
+
+        # Find shuvcode call
+        shuvcode_calls = [c for c in calls if "shuvcode" in c["cmd"]]
+        assert len(shuvcode_calls) == 1
+
+        call_info = shuvcode_calls[0]
+        cmd = call_info["cmd"]
+        env = call_info["env"]
+        assert "shuvcode" in cmd
+        assert str(worktree_path) in cmd
+        assert "--prompt" not in cmd  # No prompt flag
+        assert "run" not in cmd  # Not in CI mode
+        assert env is None or "OPENCODE_PERMISSION" not in env  # No auto-permission
+
+    @patch("subprocess.run")
+    def test_ci_mode_sets_permission_env_var(
+        self, mock_run: Mock, temp_worktree_root: Path, sample_issue_data: IssueData
+    ) -> None:
+        """Test CI mode sets OPENCODE_PERMISSION environment variable."""
+        # Track subprocess calls
+        calls = []
+
+        def track_calls(*args, **kwargs):
+            calls.append(
+                {"cmd": list(args[0]) if args else [], "env": kwargs.get("env")}
+            )
+            mock_result = Mock()
+            mock_result.stdout = ""
+            mock_result.returncode = 0
+            return mock_result
+
+        mock_run.side_effect = track_calls
+
+        settings = WorktreeSettings(worktree_root=temp_worktree_root, ci_mode=True)
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+
+        # Create WT-TASK.md
+        task_file = worktree_path / "WT-TASK.md"
+        task_file.write_text("Test task content")
+
+        # Open shuvcode in CI mode
+        creator._open_shuvcode(worktree_path)
+
+        # Find shuvcode call
+        shuvcode_calls = [c for c in calls if "shuvcode" in c["cmd"]]
+        assert len(shuvcode_calls) == 1
+
+        call_info = shuvcode_calls[0]
+        cmd = call_info["cmd"]
+        env = call_info["env"]
+
+        # Verify CI mode command
+        assert "shuvcode" in cmd
+        assert "run" in cmd
+        assert "--prompt" not in cmd  # No --prompt flag in CI mode
+
+        # Verify OPENCODE_PERMISSION is set
+        assert env is not None, "Environment should be passed to subprocess"
+        assert "OPENCODE_PERMISSION" in env, (
+            "OPENCODE_PERMISSION should be set in CI mode"
+        )
+        assert env["OPENCODE_PERMISSION"] == '{"*":"allow"}'
+
+    @patch("subprocess.run")
+    def test_dry_run_skips_shuvcode(
+        self, mock_run: Mock, temp_worktree_root: Path
+    ) -> None:
+        """Test dry-run mode skips shuvcode entirely."""
+        settings = WorktreeSettings(worktree_root=temp_worktree_root)
+        creator = WorktreeCreator(
+            issue_fetcher=Mock(),
+            template_renderer=Mock(),
+            settings=settings,
+            dry_run=True,
+        )
+
+        worktree_path = temp_worktree_root / "test-branch"
+
+        # Open shuvcode in dry-run mode
+        creator._open_shuvcode(worktree_path)
+
+        # Verify subprocess not called
+        mock_run.assert_not_called()

--- a/worktree_creator.py
+++ b/worktree_creator.py
@@ -1,21 +1,26 @@
 """Worktree creation and management."""
 
 import contextlib
+import os
 import re
 import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
 
 import structlog
-from config import WorktreeSettings
+from config import WorktreeSettings, PROMPT_PRESETS
 from github_fetcher import GitHubIssueFetcher
 from models import IssueData, PRData
 from template_renderer import TemplateRenderer
 
-ERROR_WORKMUX_NOT_INSTALLED = "workmux is not installed. Install from https://github.com/yourusername/workmux"
+ERROR_WORKMUX_NOT_INSTALLED = (
+    "workmux is not installed. Install from https://github.com/yourusername/workmux"
+)
 ERROR_FAILED_TO_CREATE_WORKTREE = "Failed to create worktree: {error}"
 ERROR_FAILED_TO_WRITE_TASK_FILE = "Failed to write WT-TASK.md to {path}"
-ERROR_USER_CANCELLED_BRANCH_CONFLICT = "User cancelled. Branch '{branch}' already exists."
+ERROR_USER_CANCELLED_BRANCH_CONFLICT = (
+    "User cancelled. Branch '{branch}' already exists."
+)
 
 # Regex patterns
 GITHUB_URL_PATTERN = r"github\.com/([^/]+)/([^/]+)/(issues|pull)/(\d+)"
@@ -41,7 +46,9 @@ class WorktreeCreator:
             settings: Configuration settings
             dry_run: If True, skip workmux and only generate WT-TASK.md
         """
-        self.logger: structlog.typing.FilteringBoundLogger = structlog.get_logger(__name__)
+        self.logger: structlog.typing.FilteringBoundLogger = structlog.get_logger(
+            __name__
+        )
         self.issue_fetcher: GitHubIssueFetcher = issue_fetcher
         self.template_renderer: TemplateRenderer = template_renderer
         self.settings: WorktreeSettings = settings
@@ -75,7 +82,9 @@ class WorktreeCreator:
         )
 
         # Parse URL to extract owner, repo, number, type
-        item_type, owner, repo, number = self._parse_github_url(url_or_number, item_type)
+        item_type, owner, repo, number = self._parse_github_url(
+            url_or_number, item_type
+        )
 
         self.logger.debug(
             "Parsed GitHub URL",
@@ -326,11 +335,17 @@ class WorktreeCreator:
 
                 # Branch exists - prompt for removal
                 response = (
-                    input(f"Branch '{branch_name}' already exists. Remove existing worktree? (y/n): ").strip().lower()
+                    input(
+                        f"Branch '{branch_name}' already exists. Remove existing worktree? (y/n): "
+                    )
+                    .strip()
+                    .lower()
                 )
 
                 if response == "y":
-                    self.logger.info("Removing existing worktree", branch_name=branch_name)
+                    self.logger.info(
+                        "Removing existing worktree", branch_name=branch_name
+                    )
                     # Remove existing worktree
                     _ = subprocess.run(
                         ["workmux", "remove", branch_name],
@@ -339,12 +354,22 @@ class WorktreeCreator:
                         text=True,
                         timeout=self.settings.workmux_timeout,
                     )
-                    self.logger.debug("Existing worktree removed successfully", branch_name=branch_name)
+                    self.logger.debug(
+                        "Existing worktree removed successfully",
+                        branch_name=branch_name,
+                    )
                 else:
-                    self.logger.info("User cancelled worktree creation due to branch conflict", branch_name=branch_name)
-                    raise RuntimeError(ERROR_USER_CANCELLED_BRANCH_CONFLICT.format(branch=branch_name))
+                    self.logger.info(
+                        "User cancelled worktree creation due to branch conflict",
+                        branch_name=branch_name,
+                    )
+                    raise RuntimeError(
+                        ERROR_USER_CANCELLED_BRANCH_CONFLICT.format(branch=branch_name)
+                    )
             else:
-                self.logger.debug("No branch conflict detected", branch_name=branch_name)
+                self.logger.debug(
+                    "No branch conflict detected", branch_name=branch_name
+                )
 
         except subprocess.CalledProcessError as e:
             self.logger.warning(
@@ -371,7 +396,10 @@ class WorktreeCreator:
             RuntimeError: If worktree creation fails (not in dry-run mode)
         """
         if self._dry_run:
-            self.logger.debug("Dry-run mode: creating temporary directory for WT-TASK.md", branch_name=branch_name)
+            self.logger.debug(
+                "Dry-run mode: creating temporary directory for WT-TASK.md",
+                branch_name=branch_name,
+            )
             # Dry-run mode: create temporary directory for WT-TASK.md only
             worktree_path = Path(self._worktree_root) / branch_name
             worktree_path.mkdir(parents=True, exist_ok=True)
@@ -396,7 +424,9 @@ class WorktreeCreator:
             match = re.search(WORKMUX_CREATED_PATTERN, result.stdout)
             if match:
                 worktree_path = Path(match.group(1))
-                self.logger.debug("Extracted worktree path from output", path=str(worktree_path))
+                self.logger.debug(
+                    "Extracted worktree path from output", path=str(worktree_path)
+                )
                 return worktree_path
 
             # Fallback: construct path manually using configured worktree root
@@ -412,8 +442,14 @@ class WorktreeCreator:
                 error_msg = e.stderr
             else:
                 error_msg = e.stderr.decode("utf-8", errors="replace")
-            self.logger.error("Failed to create worktree", branch_name=branch_name, error=error_msg[:500])
-            raise RuntimeError(ERROR_FAILED_TO_CREATE_WORKTREE.format(error=error_msg)) from e
+            self.logger.error(
+                "Failed to create worktree",
+                branch_name=branch_name,
+                error=error_msg[:500],
+            )
+            raise RuntimeError(
+                ERROR_FAILED_TO_CREATE_WORKTREE.format(error=error_msg)
+            ) from e
         except subprocess.TimeoutExpired as e:
             self.logger.error("Timeout creating worktree", branch_name=branch_name)
             raise RuntimeError(f"Timeout creating worktree '{branch_name}'") from e
@@ -435,7 +471,9 @@ class WorktreeCreator:
         Raises:
             RuntimeError: If file write fails
         """
-        self.logger.debug("Rendering WT-TASK.md template", worktree_path=str(worktree_path))
+        self.logger.debug(
+            "Rendering WT-TASK.md template", worktree_path=str(worktree_path)
+        )
 
         # Generate content with full path context
         if isinstance(data, IssueData):
@@ -458,13 +496,67 @@ class WorktreeCreator:
 
         try:
             _ = task_file_path.write_text(content)
-            self.logger.info("WT-TASK.md written successfully", path=str(task_file_path))
+            self.logger.info(
+                "WT-TASK.md written successfully", path=str(task_file_path)
+            )
         except OSError as e:
-            self.logger.error("Failed to write WT-TASK.md", path=str(task_file_path), error=str(e))
-            raise RuntimeError(ERROR_FAILED_TO_WRITE_TASK_FILE.format(path=task_file_path)) from e
+            self.logger.error(
+                "Failed to write WT-TASK.md", path=str(task_file_path), error=str(e)
+            )
+            raise RuntimeError(
+                ERROR_FAILED_TO_WRITE_TASK_FILE.format(path=task_file_path)
+            ) from e
+
+    def _resolve_shuvcode_prompt(self, worktree_path: Path) -> str | None:
+        """Resolve prompt content for shuvcode based on priority.
+
+        Priority order:
+        1. Custom --agent-prompt flag
+        2. GHWT_AGENT_INIT_PROMPT env var (via settings.agent_prompt)
+        3. GHWT_AGENT_INIT_PRESET env var (via settings.agent_prompt_preset)
+        4. WT-TASK.md file content
+        5. None (no prompt)
+
+        Args:
+            worktree_path: Path to worktree directory
+
+        Returns:
+            Prompt content or None
+        """
+        # Priority 1: Custom prompt (CLI flag or env var)
+        if self.settings.agent_prompt:
+            self.logger.debug("Using custom agent prompt")
+            return self.settings.agent_prompt
+
+        # Priority 2: Preset (CLI flag or env var)
+        if self.settings.agent_prompt_preset:
+            preset = PROMPT_PRESETS[self.settings.agent_prompt_preset]
+            self.logger.debug(
+                "Using preset prompt",
+                preset=self.settings.agent_prompt_preset.value,
+            )
+            return preset
+
+        # Priority 3: WT-TASK.md content
+        task_file = worktree_path / "WT-TASK.md"
+        if task_file.exists():
+            content = task_file.read_text()
+            self.logger.debug("Using WT-TASK.md as prompt", length=len(content))
+            return content
+
+        # Priority 4: No prompt (--no-prompt or file missing)
+        if self.settings.no_prompt:
+            self.logger.debug("No prompt (no-prompt flag set)")
+
+        return None
 
     def _open_shuvcode(self, worktree_path: Path) -> None:
-        """Open shuvcode on worktree.
+        """Open shuvcode on worktree with prompt based on settings.
+
+        Behavior:
+        - CI mode: `shuvcode run "<prompt>"` (non-interactive)
+        - Normal mode: `shuvcode <path> --prompt "<prompt>"` (interactive)
+        - No prompt: `shuvcode <path>` (current behavior)
 
         Args:
             worktree_path: Path to worktree directory
@@ -477,13 +569,44 @@ class WorktreeCreator:
             self.logger.debug("Skipping shuvcode in dry-run mode")
             return
 
-        self.logger.debug("Opening shuvcode", worktree_path=str(worktree_path))
+        if self.settings.no_prompt:
+            self.logger.debug("Skipping prompt (no-prompt flag)")
+            cmd = ["shuvcode", str(worktree_path)]
+            env = None  # Use parent process environment
+        else:
+            prompt = self._resolve_shuvcode_prompt(worktree_path)
 
-        with contextlib.suppress(subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+            if not prompt:
+                self.logger.debug("No prompt available, opening shuvcode normally")
+                cmd = ["shuvcode", str(worktree_path)]
+                env = None  # Use parent process environment
+            elif self.settings.ci_mode:
+                # CI mode: non-interactive execution with auto-permissions
+                self.logger.info(
+                    "Opening shuvcode in CI mode", prompt_length=len(prompt)
+                )
+                cmd = ["shuvcode", "run", prompt]
+                # Set OPENCODE_PERMISSION to auto-allow all operations in CI
+                env = os.environ.copy()
+                env["OPENCODE_PERMISSION"] = '{"*":"allow"}'
+            else:
+                # Interactive mode with initial prompt
+                self.logger.info(
+                    "Opening shuvcode with prompt", prompt_length=len(prompt)
+                )
+                cmd = ["shuvcode", str(worktree_path), "--prompt", prompt]
+                env = None  # Use parent process environment
+
+        self.logger.debug("Executing shuvcode command", command=" ".join(cmd))
+
+        with contextlib.suppress(
+            subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired
+        ):
             _ = subprocess.run(
-                ["shuvcode", str(worktree_path)],
+                cmd,
                 check=False,
                 capture_output=True,
                 text=True,
                 timeout=self.settings.file_write_timeout,
+                env=env,
             )


### PR DESCRIPTION
## Summary

Implements issue #19: Add --ci flag for non-interactive shuvcode execution with automatic permission handling.

### Features Added

1. **Prompt Passing System**
   - `PromptPreset` enum: RALPH_LOOP, STANDARD_OOTL, MINIMAL
   - `PROMPT_PRESETS` dict with detailed instructions for each preset
   - Priority order: CLI flag > env var > WT-TASK.md > None

2. **CLI Flags**
   - `--agent-prompt`: Custom prompt override
   - `--agent-preset ralph-loop|standard-ootl|minimal`: Preset selection
   - `--no-prompt`: Disable prompt passing (old behavior)
   - `--ci`: Non-interactive mode with auto-permissions

3. **Configuration**
   - Added prompt settings to `WorktreeSettings`
   - Model validator for mutually exclusive prompt flags
   - CLI-level validation: `--ci` and `--no-prompt` cannot be used together

4. **Core Logic**
   - `_resolve_shuvcode_prompt()`: Implements priority order
   - `_open_shuvcode()`: Supports 3 modes:
     - CI mode: `shuvcode run "<prompt>"` + `OPENCODE_PERMISSION='{"*":"allow"}'`
     - Normal mode: `shuvcode <path> --prompt "<prompt>"`
     - No prompt: `shuvcode <path>` (old behavior)

5. **Testing**
   - 9 tests covering all prompt resolution scenarios
   - Tests verify command generation and environment variable setting
   - New test validates CI mode env var

6. **Documentation**
   - Updated README with usage examples
   - CI/CD integration examples (GitHub Actions, GitLab CI)
   - Note about automatic `OPENCODE_PERMISSION` setting

### CI Mode Behavior

When `--ci` flag is used:
```bash
# Uses non-interactive execution with auto-permissions
ghwt 42 --issue --ci
# → shuvcode run "WT-TASK.md" + OPENCODE_PERMISSION='{"*":"allow"}'
```

**Key benefits:**
- No TUI interface (uses `shuvcode run`)
- Auto-approves all operations via `OPENCODE_PERMISSION` environment variable
- Perfect for CI/CD pipelines and automated workflows

### Usage Examples

```bash
# CI mode - fully non-interactive
ghwt 42 --issue --ci

# CI mode with custom prompt
ghwt 42 --issue --ci --agent-prompt "Execute specific task"

# CI mode with preset
ghwt 42 --issue --ci --agent-preset ralph-loop

# Normal interactive mode with prompt
ghwt 42 --issue --agent-prompt "Custom instructions"

# No prompt (old behavior)
ghwt 42 --issue --no-prompt
```

### Test Results

```
tests/unit/test_prompt_passing.py: 9/9 passed ✅
tests/unit/test_config.py: 11/11 passed ✅
Full test suite: 87/89 passed (2 pre-existing failures) ✅
Code quality: ruff checks pass ✅
```

### Files Modified

- `config.py`: Added enums, presets, validators
- `main.py`: Added CLI flags and validation
- `worktree_creator.py`: Added prompt resolution and CI mode
- `tests/unit/test_prompt_passing.py`: 9 new tests
- `tests/unit/test_config.py`: 11 validation tests
- `README.md`: Documentation and examples

### Issue #20 Closure

Issue #20 (YOLO flag) has been closed as redundant. The `--ci` flag implemented in this PR provides the requested autonomous execution functionality:

- `--ci` uses non-interactive `shuvcode run` command
- `OPENCODE_PERMISSION='{"*":"allow"}'` auto-approves all operations
- Users wanting custom autonomous behavior can use `--ci --agent-prompt`

Separate `--yolo` flag would duplicate functionality without adding value.

### Acceptance Criteria

- ✅ WT-TASK.md content is automatically passed to shuvcode
- ✅ `--agent-prompt` flag overrides WT-TASK.md content
- ✅ `--no-prompt` flag disables prompt passing (current behavior)
- ✅ `GHWT_AGENT_INIT_PROMPT` environment variable is respected
- ✅ `GHWT_AGENT_INIT_PRESET` environment variable selects predefined preset
- ✅ Shuvcode opens with prompt pre-loaded using `--prompt` flag
- ✅ Tests verify prompt passing to shuvcode subprocess
- ✅ Documentation includes all usage patterns and CI/CD examples
- ✅ CI mode sets `OPENCODE_PERMISSION` environment variable for non-interactive execution

Closes #19
Related: Closed #20